### PR TITLE
Support fat32 boot partitions.

### DIFF
--- a/board/samsung/aries/aries.c
+++ b/board/samsung/aries/aries.c
@@ -308,17 +308,17 @@ int setup_bootmenu(void)
 
 	/* Setup SD/MMC */
 	if (!gpio_get_value(S5PC110_GPIO_H34)) {
-		env_set("bootmenu_3", "SD Card Partition 1 Boot=ext4load mmc 0:1 ${kernel_load_addr} uImage; bootm ${kernel_load_addr};");
-		env_set("bootmenu_4", "SD Card Partition 2 Boot=ext4load mmc 0:2 ${kernel_load_addr} uImage; bootm ${kernel_load_addr};");
+		env_set("bootmenu_3", "SD Card Partition 1 Boot=setenv mmcdev 0; setenv mmcpart 1; run mmcboot;");
+		env_set("bootmenu_4", "SD Card Partition 2 Boot=setenv mmcdev 0; setenv mmcpart 2; run mmcboot;");
 		env_set("bootmenu_5", "SD Card - Mass Storage=ums 0 mmc 0;");
 		if (cur_board != BOARD_FASCINATE4G && cur_board != BOARD_GALAXYS4G) {
-			env_set("bootmenu_6", "MMC Partition 1 Boot=ext4load mmc 1:1 ${kernel_load_addr} uImage; bootm ${kernel_load_addr};");
-			env_set("bootmenu_7", "MMC Partition 2 Boot=ext4load mmc 1:2 ${kernel_load_addr} uImage; bootm ${kernel_load_addr};");
+			env_set("bootmenu_6", "MMC Partition 1 Boot=setenv mmcdev 1; setenv mmcpart 1; run mmcboot;");
+			env_set("bootmenu_7", "MMC Partition 2 Boot=setenv mmcdev 1; setenv mmcpart 2; run mmcboot;");
 			env_set("bootmenu_8", "MMC - Mass Storage=ums 0 mmc 1;");
 		}
 	} else if (cur_board != BOARD_FASCINATE4G && cur_board != BOARD_GALAXYS4G) {
-		env_set("bootmenu_3", "MMC Partition 1 Boot=ext4load mmc 0:1 ${kernel_load_addr} uImage; bootm ${kernel_load_addr};");
-		env_set("bootmenu_4", "MMC Partition 2 Boot=ext4load mmc 0:2 ${kernel_load_addr} uImage; bootm ${kernel_load_addr};");
+		env_set("bootmenu_3", "MMC Partition 1 Boot=setenv mmcdev 0; setenv mmcpart 1; run mmcboot;");
+		env_set("bootmenu_4", "MMC Partition 2 Boot=setenv mmcdev 0; setenv mmcpart 2; run mmcboot;");
 		env_set("bootmenu_5", "MMC - Mass Storage=ums 0 mmc 0;");
 	}
 

--- a/include/configs/s5p_aries.h
+++ b/include/configs/s5p_aries.h
@@ -80,6 +80,14 @@
 	"stdin=serial,gpio-keys\0" \
 	"stdout=serial,vidconsole\0" \
 	"stderr=serial,vidconsole\0" \
+	"mmcdev=0\0" \
+	"mmcpart=1\0" \
+	"mmcboot="\
+		"ext4load mmc ${mmcdev}:${mmcpart} ${kernel_load_addr} uImage "\
+		"|| ext4load mmc ${mmcdev}:${mmcpart} ${kernel_load_addr} /boot/uImage "\
+		"|| fatload mmc ${mmcdev}:${mmcpart} ${kernel_load_addr} uImage "\
+		"|| fatload mmc ${mmcdev}:${mmcpart} ${kernel_load_addr} /boot/uImage; "\
+		"bootm ${kernel_load_addr}\0"\
 	"bootmenu_1=OneNAND Main Boot=onenand read ${kernel_load_addr} 0x1980000 0xA00000; bootm ${kernel_load_addr}\0" \
 	"bootmenu_2=OneNAND Recovery Boot=onenand read ${kernel_load_addr} 0x2380000 0xA00000; bootm ${kernel_load_addr}\0" \
 	"boot_mode=normal\0"


### PR DESCRIPTION
I've extracted boot command and added support for uImage inside /boot directory (since now mainline kernel will be booting from first partition.
Also it will be easier/possible to update kernel (on fat32 boot), using for OS which don't have native ext4 support (Windows/MacOS).