### PR TITLE
Support loading fdt (dtb) files and passing bootargs (only on linux kernel)

### DIFF
--- a/board/samsung/aries/aries.c
+++ b/board/samsung/aries/aries.c
@@ -25,6 +25,17 @@
 
 DECLARE_GLOBAL_DATA_PTR;
 
+static const char *board_linux_fdt_name[BOARD_MAX] = {
+	[BOARD_UNKNOWN] = "s5pv210-aries.dtb",
+	[BOARD_CAPTIVATE] = "s5pv210-aries.dtb",
+	[BOARD_FASCINATE] = "s5pv210-aries.dtb",
+	[BOARD_FASCINATE4G] = "s5pv210-fascinate4g.dtb",
+	[BOARD_GALAXYS] = "s5pv210-galaxys.dtb",
+	[BOARD_GALAXYS4G] = "s5pv210-fascinate4g.dtb",
+	[BOARD_GALAXYSB] = "s5pv210-aries.dtb",
+	[BOARD_VIBRANT] = "s5pv210-aries.dtb",
+};
+
 u32 get_board_rev(void)
 {
 	int i;
@@ -255,6 +266,7 @@ int misc_init_r(void)
 {
 #ifdef CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG
 	set_board_info();
+	env_set("fdtfile", board_linux_fdt_name[cur_board]);
 #endif
 	return 0;
 }

--- a/board/samsung/aries/aries.c
+++ b/board/samsung/aries/aries.c
@@ -267,6 +267,15 @@ int misc_init_r(void)
 #ifdef CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG
 	set_board_info();
 	env_set("fdtfile", board_linux_fdt_name[cur_board]);
+	switch(cur_board) {
+		case BOARD_FASCINATE4G:
+		case BOARD_GALAXYS4G:
+			env_set("sddev", "1");
+			break;
+		default:
+			env_set("sddev", "2");
+			break;
+	}
 #endif
 	return 0;
 }
@@ -320,17 +329,17 @@ int setup_bootmenu(void)
 
 	/* Setup SD/MMC */
 	if (!gpio_get_value(S5PC110_GPIO_H34)) {
-		env_set("bootmenu_3", "SD Card Partition 1 Boot=setenv mmcdev 0; setenv mmcpart 1; run mmcboot;");
-		env_set("bootmenu_4", "SD Card Partition 2 Boot=setenv mmcdev 0; setenv mmcpart 2; run mmcboot;");
+		env_set("bootmenu_3", "SD Card Partition 1 Boot=setenv mmcdev 0; setenv mmcpart 1; setenv rootdev ${sddev}; run mmcboot;");
+		env_set("bootmenu_4", "SD Card Partition 2 Boot=setenv mmcdev 0; setenv mmcpart 2; setenv rootdev ${sddev}; run mmcboot;");
 		env_set("bootmenu_5", "SD Card - Mass Storage=ums 0 mmc 0;");
 		if (cur_board != BOARD_FASCINATE4G && cur_board != BOARD_GALAXYS4G) {
-			env_set("bootmenu_6", "MMC Partition 1 Boot=setenv mmcdev 1; setenv mmcpart 1; run mmcboot;");
-			env_set("bootmenu_7", "MMC Partition 2 Boot=setenv mmcdev 1; setenv mmcpart 2; run mmcboot;");
+			env_set("bootmenu_6", "MMC Partition 1 Boot=setenv mmcdev 1; setenv mmcpart 1; setenv rootdev 0; run mmcboot;");
+			env_set("bootmenu_7", "MMC Partition 2 Boot=setenv mmcdev 1; setenv mmcpart 2; setenv rootdev 0; run mmcboot;");
 			env_set("bootmenu_8", "MMC - Mass Storage=ums 0 mmc 1;");
 		}
 	} else if (cur_board != BOARD_FASCINATE4G && cur_board != BOARD_GALAXYS4G) {
-		env_set("bootmenu_3", "MMC Partition 1 Boot=setenv mmcdev 0; setenv mmcpart 1; run mmcboot;");
-		env_set("bootmenu_4", "MMC Partition 2 Boot=setenv mmcdev 0; setenv mmcpart 2; run mmcboot;");
+		env_set("bootmenu_3", "MMC Partition 1 Boot=setenv mmcdev 0; setenv mmcpart 1; setenv rootdev 0; run mmcboot;");
+		env_set("bootmenu_4", "MMC Partition 2 Boot=setenv mmcdev 0; setenv mmcpart 2; setenv rootdev 0; run mmcboot;");
 		env_set("bootmenu_5", "MMC - Mass Storage=ums 0 mmc 0;");
 	}
 

--- a/include/configs/s5p_aries.h
+++ b/include/configs/s5p_aries.h
@@ -76,16 +76,34 @@
 	"bootchart=set opts init=/sbin/bootchartd; run bootcmd\0" \
 	"console=" CONFIG_DEFAULT_CONSOLE "\0"\
 	"kernel_load_addr=0x32000000\0" \
+	"fdt_load_addr=0x33000000\0" \
 	"meminfo=mem=80M mem=256M@0x40000000 mem=128M@0x50000000\0" \
 	"stdin=serial,gpio-keys\0" \
 	"stdout=serial,vidconsole\0" \
 	"stderr=serial,vidconsole\0" \
+	"opts=ignore_loglevel earlyprintk\0" \
+	"check_dtb=" \
+		"if run loaddtb; then " \
+			"setenv fdt_addr ${fdt_load_addr};" \
+		"else " \
+			"setenv fdt_addr;" \
+		"fi;\0" \
+	"loadkernel=" \
+		"load mmc ${mmcdev}:${mmcpart} ${kernel_load_addr} uImage "\
+		"|| load mmc ${mmcdev}:${mmcpart} ${kernel_load_addr} /boot/uImage;\0" \
+	"loaddtb=" \
+		"load mmc ${mmcdev}:${mmcpart} ${fdt_load_addr} ${fdtfile} "\
+		"|| load mmc ${mmcdev}:${mmcpart} ${fdt_load_addr} /boot/${fdtfile};\0" \
+	"setup_kernel_args=" \
+		"setenv bootargs root=/dev/mmcblk${mmcdev}p${mmcpart}" \
+		" rootwait ${console} ${meminfo} ${opts};\0" \
 	"mmcdev=0\0" \
 	"mmcpart=1\0" \
 	"mmcboot="\
-		"load mmc ${mmcdev}:${mmcpart} ${kernel_load_addr} uImage "\
-		"|| load mmc ${mmcdev}:${mmcpart} ${kernel_load_addr} /boot/uImage; "\
-		"bootm ${kernel_load_addr}\0"\
+		"run check_dtb;" \
+		"run loadkernel;" \
+		"run setup_kernel_args;" \
+		"bootm ${kernel_load_addr} - ${fdt_addr}\0"\
 	"bootmenu_1=OneNAND Main Boot=onenand read ${kernel_load_addr} 0x1980000 0xA00000; bootm ${kernel_load_addr}\0" \
 	"bootmenu_2=OneNAND Recovery Boot=onenand read ${kernel_load_addr} 0x2380000 0xA00000; bootm ${kernel_load_addr}\0" \
 	"boot_mode=normal\0"

--- a/include/configs/s5p_aries.h
+++ b/include/configs/s5p_aries.h
@@ -95,8 +95,10 @@
 		"load mmc ${mmcdev}:${mmcpart} ${fdt_load_addr} ${fdtfile} "\
 		"|| load mmc ${mmcdev}:${mmcpart} ${fdt_load_addr} /boot/${fdtfile};\0" \
 	"setup_kernel_args=" \
-		"setenv bootargs root=/dev/mmcblk${mmcdev}p${mmcpart}" \
+		"setenv bootargs root=/dev/mmcblk${rootdev}p${mmcpart}" \
 		" rootwait ${console} ${meminfo} ${opts};\0" \
+	"sddev=1\0" \
+	"rootdev=1\0" \
 	"mmcdev=0\0" \
 	"mmcpart=1\0" \
 	"mmcboot="\


### PR DESCRIPTION
With this few commits it's possible to place and load dtb file (it should be placed in the same directory as uImage), so we don't have to use appended images (and can use single zImage for all boards).
Also we can now remove hardcoded parameters from linux kernel dts files.

Optional parameters can be added to opts env variable in uboot.

sddev env variable is needed, because:
- if we don't have mmc -> mmcblk0 = wifi, sdcard mmcblk1
- if we have mmc -> mmcblk0 = mmc, mmcblk1 = wifi, mmcblk2 = sd

Need testing.