### PR TITLE
aries: Export mtdparts to kernel cmdline

### DIFF
--- a/board/samsung/aries/aries.c
+++ b/board/samsung/aries/aries.c
@@ -271,9 +271,11 @@ int misc_init_r(void)
 		case BOARD_FASCINATE4G:
 		case BOARD_GALAXYS4G:
 			env_set("sddev", "1");
+			env_set("mtdparts", "b0600000.onenand:256k@25856k(uboot-env),10240k(boot),10240k(recovery),980480k(ubi)");
 			break;
 		default:
 			env_set("sddev", "2");
+			env_set("mtdparts", "b0600000.onenand:256k@25856k(uboot-env),10240k(boot),10240k(recovery),466432k(ubi)");
 			break;
 	}
 #endif

--- a/configs/s5p_aries_defconfig
+++ b/configs/s5p_aries_defconfig
@@ -7,7 +7,7 @@ CONFIG_ENV_VARS_UBOOT_CONFIG=y
 CONFIG_ANDROID_BOOT_IMAGE=y
 CONFIG_BOOTDELAY=0
 CONFIG_USE_BOOTCOMMAND=y
-CONFIG_BOOTCOMMAND="setenv bootargs ${console} ${mtdparts} androidboot.mode=${boot_mode} androidboot.serialno=${serial#}; bootmenu 2;"
+CONFIG_BOOTCOMMAND="setenv bootargs ${console} mtdparts=${mtdparts} ubi.mtd=ubi androidboot.mode=${boot_mode} androidboot.serialno=${serial#}; bootmenu 2;"
 CONFIG_BOARD_EARLY_INIT_F=y
 CONFIG_HUSH_PARSER=y
 # CONFIG_AUTO_COMPLETE is not set
@@ -35,6 +35,7 @@ CONFIG_CMD_FS_GENERIC=y
 CONFIG_CMD_MTDPARTS=y
 CONFIG_OF_LIST="s5pc1xx-aries s5pc1xx-fascinate4g s5pc1xx-galaxys"
 CONFIG_MULTI_DTB_FIT=y
+CONFIG_ENV_IS_IN_ONENAND=y
 CONFIG_ENV_VARS_UBOOT_RUNTIME_CONFIG=y
 # CONFIG_NET is not set
 CONFIG_DFU_MMC=y

--- a/env/env.c
+++ b/env/env.c
@@ -68,6 +68,9 @@ static enum env_location env_locations[] = {
 #ifdef CONFIG_ENV_IS_IN_NVRAM
 	ENVL_NVRAM,
 #endif
+#ifdef CONFIG_ENV_IS_IN_ONENAND
+	ENVL_ONENAND,
+#endif
 #ifdef CONFIG_ENV_IS_IN_REMOTE
 	ENVL_REMOTE,
 #endif

--- a/include/configs/s5p_aries.h
+++ b/include/configs/s5p_aries.h
@@ -102,7 +102,7 @@
 		"|| load mmc ${mmcdev}:${mmcpart} ${fdt_load_addr} /boot/${fdtfile};\0" \
 	"setup_kernel_args=" \
 		"setenv bootargs root=/dev/mmcblk${rootdev}p${mmcpart}" \
-		" rootwait rw ${console} ${meminfo} ${opts};\0" \
+		" rootwait rw ${console} ${meminfo} ${opts} mtdparts=${mtdparts} ubi.mtd=ubi;\0" \
 	"sddev=1\0" \
 	"rootdev=1\0" \
 	"uboot_update=if test -e mmc 0:1 u-boot.bin; then "\
@@ -143,8 +143,8 @@
 #define CONFIG_SYS_MONITOR_LEN		(256 << 10)	/* 256 KiB */
 
 /* Environment organization */
-#define CONFIG_ENV_SIZE			4096
-#define CONFIG_ENV_OFFSET		((32 - 4) << 10) /* 32KiB - 4KiB */
+#define CONFIG_ENV_SIZE			(256 << 10) /* 256k */
+#define CONFIG_ENV_ADDR			(25856 << 10) /* 25856k */
 
 #define CONFIG_USE_ONENAND_BOARD_INIT
 #define CONFIG_SYS_ONENAND_BASE		0xB0000000


### PR DESCRIPTION
Currently ENV is still nowhere as ENV_IN_ONENAND doesn't appear to work

MTD ID is set to b0600000.onenand as that's the name of the MTD device in the mainline kernel.  In the vendor kernel, there is no mtd->name, so it simply takes the first mtdparts that is present.