### PR TITLE
mmc: s5p_sdhci: Incrase max_clk to fix problems with mmc

### DIFF
--- a/drivers/mmc/s5p_sdhci.c
+++ b/drivers/mmc/s5p_sdhci.c
@@ -90,7 +90,7 @@ static int s5p_sdhci_core_init(struct sdhci_host *host)
 	host->quirks = SDHCI_QUIRK_NO_HISPD_BIT | SDHCI_QUIRK_BROKEN_VOLTAGE |
 		SDHCI_QUIRK_32BIT_DMA_ADDR |
 		SDHCI_QUIRK_WAIT_SEND_CMD | SDHCI_QUIRK_USE_WIDE8;
-	host->max_clk = 52000000;
+	host->max_clk = 133400000;
 	host->voltages = MMC_VDD_32_33 | MMC_VDD_33_34 | MMC_VDD_165_195;
 	host->ops = &s5p_sdhci_ops;
 


### PR DESCRIPTION
It was observed on s5pv210 board, that with current max_clk it's not
possible to access mmc (when using mass storage in uboot).
After incrasing it to 133400000 (value reported by kernel after boot),
it's working fine.

Signed-off-by: Paweł Chmiel <pawel.mikolaj.chmiel@gmail.com>