### PR TITLE
aries: Set serial number based on PRO_ID regs

### DIFF
--- a/board/samsung/aries/aries.c
+++ b/board/samsung/aries/aries.c
@@ -413,17 +413,10 @@ int board_late_init(void)
 	uint64_t board_serial = 0;
 	char board_serial_str[17];
 
-	/* Base the serial number on the MMC card or SD if on variant without it */
+	/* Base the serial number on values in PRO_ID + 0x14/0x18 */
 	if (!env_get("serial#")) {
-		struct mmc *mmc = find_mmc_device(1);
-		if (!mmc)
-			mmc = find_mmc_device(0);
-		if (!mmc)
-			pr_err("%s: couldn't get serial number - no MMC device found!\n", __func__);
-		else if (mmc_init(mmc))
-			pr_err("%s: MMC init failed!\n", __func__);
-		else
-			board_serial = ((uint64_t)mmc->cid[2] << 32) | mmc->cid[3];
+		board_serial = (uint64_t) readl(samsung_get_base_clock() + 0x18) << 32
+				| readl(samsung_get_base_clock() + 0x14);
 
 		sprintf(board_serial_str, "%016llx", board_serial);
 		env_set("serial#", board_serial_str);


### PR DESCRIPTION
According to https://git.tizen.org/cgit/platform/kernel/linux-exynos/commit/?h=sandbox/jhoon20kim/rebase-tizen-next
the values in PRO_ID + 0x14 and 0x18 are unique for each chip.

Here's the values from my device:
Aries # md.l 0xE0000014
e0000014: 4d2338a8 000001b5 00000000 00000000    .8#M............

This doesn't match up with the stock serial number either, but it's better
than relying on an SD card that can change.