### PR TITLE
Bootmenu improvements

### DIFF
--- a/cmd/bootmenu.c
+++ b/cmd/bootmenu.c
@@ -60,6 +60,18 @@ static char *bootmenu_getoption(unsigned short int n, const char *prefix)
 	return env_get(name);
 }
 
+static char *bootmenu_getoption_str(const char *opt, const char *prefix)
+{
+	char name[MAX_ENV_SIZE];
+
+	if (prefix != NULL)
+		sprintf(name, "%s%s", prefix, opt);
+	else
+		sprintf(name, "bootmenu_%s", opt);
+
+	return env_get(name);
+}
+
 static void bootmenu_print_entry(void *data)
 {
 	struct bootmenu_entry *entry = data;
@@ -499,7 +511,7 @@ int do_bootmenu(cmd_tbl_t *cmdtp, int flag, int argc, char *const argv[])
 	}
 
 	if (!delay_str)
-		delay_str = env_get("bootmenu_delay");
+		delay_str = bootmenu_getoption_str("delay", prefix);
 
 	if (delay_str)
 		delay = (int)simple_strtol(delay_str, NULL, 10);

--- a/cmd/bootmenu.c
+++ b/cmd/bootmenu.c
@@ -330,6 +330,12 @@ static struct bootmenu_data *bootmenu_create(int delay, const char *prefix)
 			break;
 	}
 
+	/* Don't add a U-Boot console entry if we don't want it */
+	if (bootmenu_getoption_str("no_console", prefix)) {
+		menu->count = i;
+		return menu;
+	}
+
 	/* Add U-Boot console entry at the end */
 	if (i <= MAX_COUNT - 1) {
 		entry = malloc(sizeof(struct bootmenu_entry));

--- a/cmd/bootmenu.c
+++ b/cmd/bootmenu.c
@@ -35,6 +35,7 @@ struct bootmenu_data {
 	int delay;			/* delay for autoboot */
 	long active;			/* active menu entry */
 	int count;			/* total count of menu entries */
+	const char *prefix;		/* prefix to use for env cfgs */
 	struct bootmenu_entry *first;	/* first menu entry */
 };
 
@@ -281,6 +282,7 @@ static struct bootmenu_data *bootmenu_create(int delay, const char *prefix)
 
 	menu->delay = delay;
 	menu->first = NULL;
+	menu->prefix = prefix;
 
 	while ((option = bootmenu_getoption(i, prefix))) {
 		sep = strchr(option, '=');
@@ -470,16 +472,22 @@ void menu_display_statusline(struct menu *m)
 {
 	struct bootmenu_entry *entry;
 	struct bootmenu_data *menu;
+	char *title;
 
 	if (menu_default_choice(m, (void *)&entry) < 0)
 		return;
 
 	menu = entry->menu;
 
+	title = bootmenu_getoption_str("title", menu->prefix);
+
 	printf(ANSI_CURSOR_POSITION, 1, 1);
 	puts(ANSI_CLEAR_LINE);
 	printf(ANSI_CURSOR_POSITION, 2, 1);
-	puts("  *** U-Boot Boot Menu ***");
+	if (title)
+		puts(title);
+	else
+		puts("  *** U-Boot Boot Menu ***");
 	puts(ANSI_CLEAR_LINE_TO_END);
 	printf(ANSI_CURSOR_POSITION, 3, 1);
 	puts(ANSI_CLEAR_LINE);

--- a/cmd/pxe.c
+++ b/cmd/pxe.c
@@ -1597,6 +1597,9 @@ static void pxe_menu_to_bootmenu(cmd_tbl_t *cmdtp, struct pxe_menu *cfg)
 	if (default_num)
 		env_set("pxemenu_default", default_num);
 
+	if (cfg->title)
+		env_set("pxemenu_title", cfg->title);
+
 	env_set("pxemenu_no_console", "1");
 
 	/* run the bootmenu */

--- a/cmd/pxe.c
+++ b/cmd/pxe.c
@@ -1597,6 +1597,8 @@ static void pxe_menu_to_bootmenu(cmd_tbl_t *cmdtp, struct pxe_menu *cfg)
 	if (default_num)
 		env_set("pxemenu_default", default_num);
 
+	env_set("pxemenu_no_console", "1");
+
 	/* run the bootmenu */
 	sprintf(bootmenu_cmd, "bootmenu %d pxemenu_",
 		DIV_ROUND_UP(cfg->timeout, 10));


### PR DESCRIPTION
Adjust bootmenu for use with PXE so that:
* U-Boot console isn't showing up
* Title in extlinux is used
* Default option is retained if specified (although this doesn't appear to work, currently)

Fixes #32 